### PR TITLE
change pub hash from base64 to hex encoded

### DIFF
--- a/pkg/common/tpm_attestor.go
+++ b/pkg/common/tpm_attestor.go
@@ -19,7 +19,6 @@ package common
 import (
 	"crypto/rsa"
 	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
 	"net/url"
 	"strings"
@@ -65,6 +64,6 @@ func GetPubHash(cert *x509.Certificate) (string, error) {
 	pubKey := cert.PublicKey.(*rsa.PublicKey)
 	pubBytes := x509.MarshalPKCS1PublicKey(pubKey)
 	pubHash := sha256.Sum256(pubBytes)
-	hashEncoded := base64.StdEncoding.EncodeToString(pubHash[:])
+	hashEncoded := fmt.Sprintf("%x", pubHash)
 	return hashEncoded, nil
 }


### PR DESCRIPTION
[SPIFFE-ID paths](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#22-path) may be hierarchial, and using the base64 encoded Public Key Hash results in SVIDs that look like:

`spiffe://domain.test/spire/agent/tpm/c1XbxrikL+sgdCw7hKFlmh2/y/QenHiIfLazBlsG/yQ=`

This appears as if the path is hierarchial, since base64 includes `/` in it's character set

Additionally, checking  Public Key Hashses is proposed to look for an empty file on the filesystem named after the Pub Hash.  Since `/` is a directory separator on Linux, it cannot be represented in a file

Hex encoding for SHA256 representations is fairly standard practice, and would alleviate these issues